### PR TITLE
fix: add a guard for missing changed_manufacturer_data

### DIFF
--- a/src/bluemaestro_ble/parser.py
+++ b/src/bluemaestro_ble/parser.py
@@ -52,6 +52,8 @@ class BlueMaestroBluetoothDeviceData(BluetoothData):
             # ble adapters so we do not know which data is the latest
             # and we need to wait for the next update.
             return
+        if MFR_ID not in changed_manufacturer_data:
+            return
         data = changed_manufacturer_data[MFR_ID]
         if len(data) < 14:
             return

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -220,3 +220,29 @@ def test_temp_disc_thd_raw():
             ),
         },
     )
+
+
+def test_temp_disc_thd_raw_missing_data():
+    """Test 307 in the manufacturer data by raw is missing it."""
+    parser = BlueMaestroBluetoothDeviceData()
+    update = parser.update(
+        make_bluetooth_service_info(
+            name="FA17B62C",
+            manufacturer_data={307: b""},  # any will do
+            address="aa:bb:cc:dd:ee:ff",
+            rssi=-60,
+            service_data={},
+            service_uuids=[],
+            source="local",
+            raw=b"\x2a\xff",
+        )
+    )
+    assert update == SensorUpdate(
+        title=None,
+        devices={},
+        entity_descriptions={},
+        entity_values={},
+        binary_entity_descriptions={},
+        binary_entity_values={},
+        events={},
+    )


### PR DESCRIPTION
https://github.com/home-assistant/core/issues/144339